### PR TITLE
Change Uvicorn host to use both IPv4 and IPv6

### DIFF
--- a/bambuddy/rootfs/etc/services.d/bambuddy/run
+++ b/bambuddy/rootfs/etc/services.d/bambuddy/run
@@ -71,4 +71,4 @@ if bashio::config.true 'use_system_trust_store'; then
 fi
 
 bashio::log.info 'Start Bambuddy ...'
-uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 --loop asyncio
+uvicorn backend.app.main:app --host :: --port 8000 --loop asyncio


### PR DESCRIPTION
Listening on `0.0.0.0` listens on all IPv4 addresses. Listening on `::` listens on all IPv6 addresses _and_ all IPv4 addresses.