### PR TITLE
Install iproute2 so IP aliases are visible to virtual printers

### DIFF
--- a/bambuddy-daily/Dockerfile
+++ b/bambuddy-daily/Dockerfile
@@ -10,12 +10,16 @@ LABEL org.opencontainers.image.licenses="MIT License"
 WORKDIR /app
 
 # Install system dependencies
+# iproute2 replaces the BusyBox `ip` applet, which does not support `-j`.
+# Without it network interface detection silently falls back to a path that
+# cannot see IP aliases, so virtual printers cannot be bound to them.
 RUN apk add --no-cache \
   build-base \
   ca-certificates \
   py3-opencv \
   curl \
-  ffmpeg
+  ffmpeg \
+  iproute2
 
 # Install Python dependencies with cache mount
 COPY --from=builder /app/requirements.txt ./

--- a/bambuddy/Dockerfile
+++ b/bambuddy/Dockerfile
@@ -12,12 +12,16 @@ LABEL org.opencontainers.image.licenses="MIT License"
 WORKDIR /app
 
 # Install system dependencies
+# iproute2 replaces the BusyBox `ip` applet, which does not support `-j`.
+# Without it network interface detection silently falls back to a path that
+# cannot see IP aliases, so virtual printers cannot be bound to them.
 RUN apk add --no-cache \
   build-base \
   ca-certificates \
   py3-opencv \
   curl \
-  ffmpeg
+  ffmpeg \
+  iproute2
 
 # Install Python dependencies with cache mount
 COPY --from=builder /app/requirements.txt ./


### PR DESCRIPTION
Adds `iproute2` to both Dockerfiles so IP aliases are visible in the Binding Interface
picker for virtual printers.

## Problem

I set up IP aliases on my HA host to run two virtual printers, but the Binding Interface
dropdown only ever showed one address per interface, so there was no way to give the second
printer its own IP.

`GET /api/v1/settings/network-interfaces` returns just the primary address of each interface,
all with `is_alias: false`:

```json
{"interfaces": [
  {"name": "wlan0",  "ip": "192.168.1.5", "is_alias": false, "label": "wlan0"},
  {"name": "hassio", "ip": "172.30.32.1", "is_alias": false, "label": "hassio"}
]}
```

while the container itself sees all of them:

```
# docker exec app_bd367cad_bambuddy python3 -c \
    "import psutil; print([a.address for a in psutil.net_if_addrs()['wlan0'] if a.family.name=='AF_INET'])"
['192.168.1.5', '192.168.1.2', '192.168.1.3']
```

The add-on log has this on every request:

```
WARNING [backend.app.services.network_utils] ip addr show failed: BusyBox v1.37.0 multi-call binary.
ip addr add|del IFADDR dev IFACE | show|flush [dev IFACE] [to PREFIX]
```

The image is Alpine-based and `/sbin/ip` is a symlink to busybox, which doesn't support `-j`.
So `ip -j addr show` fails and `get_all_interface_ips()` falls back to
`_fallback_get_all_ips()`, which returns one address per interface with `is_alias` hardcoded
to `False`. `shutil.which("ip")` finds the busybox symlink and accepts it, so nothing catches
this earlier.

## Change

Adds `iproute2` to the `apk add` list in `bambuddy/Dockerfile` and
`bambuddy-daily/Dockerfile`, with a short comment so it isn't dropped later as unused.

## Tested

Installed the package in the running container (no restart needed, the lookup shells out per
request) and the aliases immediately showed up with `is_alias: true`. Both virtual printers
now bind to their own address and work.

Tested on HA OS 18.2 / Core 2026.8.1, raspberrypi5-64, add-on 1.2.5.3.
